### PR TITLE
Allow usage of \\.pipe\ in IKVM

### DIFF
--- a/ikvm/ikvm.include
+++ b/ikvm/ikvm.include
@@ -37,9 +37,9 @@
     <!-- HACK to support targetting .NET 4.0 when 4.5 is installed, we have to figure out the reference path ourself -->
     <if test="${version::get-major(framework::get-version(framework::get-target-framework())) == 4 and (not string::starts-with(framework::get-target-framework(), 'mono'))}">
         <if test="${environment::variable-exists('ProgramFiles(x86)')}">
-            <property name="ReferencePath" value="${environment::get-variable('ProgramFiles(x86)')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.0" />
+            <property name="ReferencePath" value="${environment::get-variable('ProgramFiles(x86)')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.5.2" />
         </if>
-        <property overwrite="false" name="ReferencePath" value="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.0" />
+        <property overwrite="false" name="ReferencePath" value="${environment::get-folder-path('ProgramFiles')}/Reference Assemblies/Microsoft/Framework/.NETFramework/v4.5.2" />
     </if>
     <property overwrite="false" name="ReferencePath" value="${framework::get-assembly-directory(framework::get-target-framework())}" />
 </project>

--- a/ikvm/runtime/openjdk/java.io.cs
+++ b/ikvm/runtime/openjdk/java.io.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Pipes;
 using System.Reflection;
 using System.Text;
 #if !NO_REF_EMIT
@@ -129,14 +130,41 @@ static class Java_java_io_FileDescriptor
 		{
 			return VirtualFileSystem.Open(name, fileMode, fileAccess);
 		}
-		else if (fileMode == FileMode.Append)
-		{
-			// this is the way to get atomic append behavior for all writes
-			return new FileStream(name, fileMode, FileSystemRights.AppendData, FileShare.ReadWrite, 1, FileOptions.None);
-		}
 		else
 		{
-			return new FileStream(name, fileMode, fileAccess, FileShare.ReadWrite, 1, false);
+			string root = Path.GetPathRoot(name);
+			if (root.StartsWith(@"\\") && root.EndsWith(@"\pipe"))
+			{
+				string host = root.Substring(2, root.Length - (5 + 2));
+				string pipeName = name.Substring(root.Length + 1);
+				PipeDirection pipeDirection = default(PipeDirection);
+				switch (fileAccess)
+				{
+					case FileAccess.Read:
+						pipeDirection = PipeDirection.In;
+						break;
+
+					case FileAccess.Write:
+						pipeDirection = PipeDirection.Out;
+						break;
+
+					case FileAccess.ReadWrite:
+						pipeDirection = PipeDirection.InOut;
+						break;
+				}
+				NamedPipeClientStream stream = new NamedPipeClientStream(host, pipeName, pipeDirection);
+				stream.Connect(0);
+				return stream;
+			}
+			else if (fileMode == FileMode.Append)
+			{
+				// this is the way to get atomic append behavior for all writes
+				return new FileStream(name, fileMode, FileSystemRights.AppendData, FileShare.ReadWrite, 1, FileOptions.None);
+			}
+			else
+			{
+				return new FileStream(name, fileMode, fileAccess, FileShare.ReadWrite, 1, false);
+			}
 		}
 	}
 

--- a/ikvm/runtime/openjdk/java.io.cs
+++ b/ikvm/runtime/openjdk/java.io.cs
@@ -153,7 +153,10 @@ static class Java_java_io_FileDescriptor
 						break;
 				}
 				NamedPipeClientStream stream = new NamedPipeClientStream(host, pipeName, pipeDirection);
-				stream.Connect(0);
+				// > [in] nDefaultTimeOut
+				// > A value of zero will result in a default time-out of 50 milliseconds.
+				// ref: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea
+				stream.Connect(50);
 				return stream;
 			}
 			else if (fileMode == FileMode.Append)

--- a/ikvm/runtime/openjdk/java.lang.invoke.cs
+++ b/ikvm/runtime/openjdk/java.lang.invoke.cs
@@ -26,7 +26,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 using IKVM.Internal;
 using java.lang.invoke;
 using jlClass = java.lang.Class;

--- a/ikvm/runtime/runtime.build
+++ b/ikvm/runtime/runtime.build
@@ -220,6 +220,7 @@
                 <include name="${ReferencePath}/mscorlib.dll" />
                 <include name="${ReferencePath}/System.dll" />
                 <include name="${ReferencePath}/System.Configuration.dll" />
+                <include name="${ReferencePath}/System.Core.dll" />
             </references>
         </csc>
         <copy file="IKVM.Runtime.dll" todir="../bin" />


### PR DESCRIPTION
Required for https://github.com/iterate-ch/cyberduck/pull/12895